### PR TITLE
fix: デプロイ方式をgit pushに修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,10 @@ jobs:
           npm install -g markdown-to-html-cli @akashic/akashic-cli
           ./.github/scripts/deploy.sh
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit and Push to gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Update GitHub Pages"
+          git push --force "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" HEAD:gh-pages


### PR DESCRIPTION
404エラーを解消するため、peaceiris/actions-gh-pagesの使用をやめ、ワークフロー内での手動git pushに切り替えます。